### PR TITLE
Add reference to Erlang library

### DIFF
--- a/erlang/readme.md
+++ b/erlang/readme.md
@@ -7,6 +7,10 @@
 - Highly available, non-stop applications
 - Hot swapping, where code can be changed without stopping a system.
 
+Erlang support a pure functional and generic programming through 3rd party libraries
+- [datum](https://github.com/fogfish/datum)
+
+
 ## Documentation
 - [Erlang Documentation](http://www.erlang.org/docs)
 
@@ -29,3 +33,4 @@ Eshell V7.3  (abort with ^G)
 2> Fun1(2).
 3
 ```
+


### PR DESCRIPTION
I've discovered your resources. They looks very interesting to me. I am studying aspects of category theory and functional programming in cereal as well. However, I am doing it with prism of Erlang and Scala. 

I've added a reference to my library that implements a few patterns which simplifies a functional programming in Erlang. I hope it will be useful of persons who is looking into you documentation. BTW, It would be interesting to get your feedback on my activity as well!